### PR TITLE
Update to be able to set ironic_fast_track

### DIFF
--- a/charts/baremetal-operator/templates/ironic.yaml
+++ b/charts/baremetal-operator/templates/ironic.yaml
@@ -81,6 +81,8 @@ spec:
               value: {{ .Values.ironic.ironic_conf.provisioning_interface }}
             - name: HTTP_PORT
               value: {{ .Values.ironic.ironic_conf.http_port | quote }}
+            - name: IRONIC_FAST_TRACK
+              value: {{ .Values.ironic.ironic_conf.ironic_fast_track }}
           volumeMounts:
             - mountPath: "/shared"
               name: ironic-storage

--- a/charts/baremetal-operator/values.yaml
+++ b/charts/baremetal-operator/values.yaml
@@ -18,6 +18,7 @@ ironic:
     http_port: "80"
     dhcp_range: "172.22.0.10,172.22.0.100"
     mariadb_password: "e8ca990d79d351eacda0"
+    ironic_fast_track: "false"
   ironic_storage:
     volume_capacity: 10Gi
     hostPath: "/opt/metal3-dev-env/ironic/"


### PR DESCRIPTION
I got error messages on ironic container that details are [here](https://github.com/metal3-io/ironic-image/issues/132).
About disabling fasttrack discussed in [ironic-image project issue#130](https://github.com/metal3-io/ironic-image/pull/130).
The Charts may need to set ironic_fast_track environment value on the ironic container.