### PR TITLE
Add ability use external baremetal-operator configs

### DIFF
--- a/charts/baremetal-operator/templates/configmaps/entrypoints/dnsmasq-entrypoint.tpl
+++ b/charts/baremetal-operator/templates/configmaps/entrypoints/dnsmasq-entrypoint.tpl
@@ -1,0 +1,37 @@
+{{- define "dnsmasq-entrypoint"}}
+#!/usr/bin/bash
+
+. /bin/ironic-common.sh
+
+HTTP_PORT=${HTTP_PORT:-"80"}
+DNSMASQ_EXCEPT_INTERFACE=${DNSMASQ_EXCEPT_INTERFACE:-"lo"}
+
+wait_for_interface_or_ip
+
+mkdir -p /shared/tftpboot
+mkdir -p /shared/html/images
+mkdir -p /shared/html/pxelinux.cfg
+
+# Copy files to shared mount
+cp /tftpboot/undionly.kpxe /tftpboot/ipxe.efi /tftpboot/snponly.efi /shared/tftpboot
+
+# Template and write dnsmasq.conf
+python3 -c 'import os; import sys; import jinja2; sys.stdout.write(jinja2.Template(sys.stdin.read()).render(env=os.environ))' </etc/dnsmasq.conf.j2 >/etc/dnsmasq.conf
+
+for iface in $( echo "$DNSMASQ_EXCEPT_INTERFACE" | tr ',' ' '); do
+    sed -i -e "/^interface=.*/ a\except-interface=${iface}" /etc/dnsmasq.conf
+done
+
+/bin/runhealthcheck "dnsmasq" &>/dev/null &
+exec /usr/sbin/dnsmasq -d -q -C /etc/dnsmasq.conf
+{{- end }}
+{{- if .Values.ironic.config_override.dnsmasq }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dnsmasq-entrypoint
+data:
+  rundnsmasq.sh: |
+    {{- include "dnsmasq-entrypoint" . | indent 4 }}
+{{- end }}

--- a/charts/baremetal-operator/templates/configmaps/entrypoints/dnsmasq-entrypoint.tpl
+++ b/charts/baremetal-operator/templates/configmaps/entrypoints/dnsmasq-entrypoint.tpl
@@ -15,12 +15,16 @@ mkdir -p /shared/html/pxelinux.cfg
 # Copy files to shared mount
 cp /tftpboot/undionly.kpxe /tftpboot/ipxe.efi /tftpboot/snponly.efi /shared/tftpboot
 
-# Template and write dnsmasq.conf
-python3 -c 'import os; import sys; import jinja2; sys.stdout.write(jinja2.Template(sys.stdin.read()).render(env=os.environ))' </etc/dnsmasq.conf.j2 >/etc/dnsmasq.conf
+if [ -f /cfg/dnsmasq.conf ]; then
+    cp -f /cfg/dnsmasq.conf /etc/dnsmasq.conf
+else
+    # Template and write dnsmasq.conf
+    python3 -c 'import os; import sys; import jinja2; sys.stdout.write(jinja2.Template(sys.stdin.read()).render(env=os.environ))' </etc/dnsmasq.conf.j2 >/etc/dnsmasq.conf
 
-for iface in $( echo "$DNSMASQ_EXCEPT_INTERFACE" | tr ',' ' '); do
-    sed -i -e "/^interface=.*/ a\except-interface=${iface}" /etc/dnsmasq.conf
-done
+    for iface in $( echo "$DNSMASQ_EXCEPT_INTERFACE" | tr ',' ' '); do
+        sed -i -e "/^interface=.*/ a\except-interface=${iface}" /etc/dnsmasq.conf
+    done
+fi
 
 /bin/runhealthcheck "dnsmasq" &>/dev/null &
 exec /usr/sbin/dnsmasq -d -q -C /etc/dnsmasq.conf

--- a/charts/baremetal-operator/templates/configmaps/entrypoints/httpd-entrypoint.tpl
+++ b/charts/baremetal-operator/templates/configmaps/entrypoints/httpd-entrypoint.tpl
@@ -15,7 +15,7 @@ cp /tmp/inspector.ipxe /shared/html/inspector.ipxe
 cp /tmp/dualboot.ipxe /shared/html/dualboot.ipxe
 cp /tmp/uefi_esp.img /shared/html/uefi_esp.img
 
-if [ -f /cfg/inspector.ipxe]; then
+if [ -f /cfg/inspector.ipxe ]; then
     cp -f /cfg/inspector.ipxe /shared/html/inspector.ipxe
 else
     # Use configured values

--- a/charts/baremetal-operator/templates/configmaps/entrypoints/httpd-entrypoint.tpl
+++ b/charts/baremetal-operator/templates/configmaps/entrypoints/httpd-entrypoint.tpl
@@ -15,17 +15,23 @@ cp /tmp/inspector.ipxe /shared/html/inspector.ipxe
 cp /tmp/dualboot.ipxe /shared/html/dualboot.ipxe
 cp /tmp/uefi_esp.img /shared/html/uefi_esp.img
 
-# Use configured values
-sed -i -e s/IRONIC_IP/${IRONIC_URL_HOST}/g -e s/HTTP_PORT/${HTTP_PORT}/g /shared/html/inspector.ipxe
-
-sed -i 's/^Listen .*$/Listen [::]:'"$HTTP_PORT"'/' /etc/httpd/conf/httpd.conf
-sed -i -e 's|\(^[[:space:]]*\)\(DocumentRoot\)\(.*\)|\1\2 "/shared/html"|' \
-    -e 's|<Directory "/var/www/html">|<Directory "/shared/html">|' \
-    -e 's|<Directory "/var/www">|<Directory "/shared">|' /etc/httpd/conf/httpd.conf
-
-# Log to std out/err
-sed -i -e 's%^ \+CustomLog.*%    CustomLog /dev/stderr combined%g' /etc/httpd/conf/httpd.conf
-sed -i -e 's%^ErrorLog.*%ErrorLog /dev/stderr%g' /etc/httpd/conf/httpd.conf
+if [ -f /cfg/inspector.ipxe]; then
+    cp -f /cfg/inspector.ipxe /shared/html/inspector.ipxe
+else
+    # Use configured values
+    sed -i -e s/IRONIC_IP/${IRONIC_URL_HOST}/g -e s/HTTP_PORT/${HTTP_PORT}/g /shared/html/inspector.ipxe
+fi
+if [ -f /cfg/httpd.conf ]; then
+    cp -f /cfg/httpd.conf /etc/httpd/conf/httpd.conf
+else
+    sed -i 's/^Listen .*$/Listen [::]:'"$HTTP_PORT"'/' /etc/httpd/conf/httpd.conf
+    sed -i -e 's|\(^[[:space:]]*\)\(DocumentRoot\)\(.*\)|\1\2 "/shared/html"|' \
+        -e 's|<Directory "/var/www/html">|<Directory "/shared/html">|' \
+        -e 's|<Directory "/var/www">|<Directory "/shared">|' /etc/httpd/conf/httpd.conf
+    # Log to std out/err
+    sed -i -e 's%^ \+CustomLog.*%    CustomLog /dev/stderr combined%g' /etc/httpd/conf/httpd.conf
+    sed -i -e 's%^ErrorLog.*%ErrorLog /dev/stderr%g' /etc/httpd/conf/httpd.conf
+fi
 
 /bin/runhealthcheck "httpd" "$HTTP_PORT" &>/dev/null &
 exec /usr/sbin/httpd -DFOREGROUND

--- a/charts/baremetal-operator/templates/configmaps/entrypoints/httpd-entrypoint.tpl
+++ b/charts/baremetal-operator/templates/configmaps/entrypoints/httpd-entrypoint.tpl
@@ -1,0 +1,44 @@
+{{- define "httpd-entrypoint"}}
+#!/usr/bin/bash
+
+. /bin/ironic-common.sh
+
+HTTP_PORT=${HTTP_PORT:-"80"}
+
+wait_for_interface_or_ip
+
+mkdir -p /shared/html
+chmod 0777 /shared/html
+
+# Copy files to shared mount
+cp /tmp/inspector.ipxe /shared/html/inspector.ipxe
+cp /tmp/dualboot.ipxe /shared/html/dualboot.ipxe
+cp /tmp/uefi_esp.img /shared/html/uefi_esp.img
+
+# Use configured values
+sed -i -e s/IRONIC_IP/${IRONIC_URL_HOST}/g -e s/HTTP_PORT/${HTTP_PORT}/g /shared/html/inspector.ipxe
+
+sed -i 's/^Listen .*$/Listen [::]:'"$HTTP_PORT"'/' /etc/httpd/conf/httpd.conf
+sed -i -e 's|\(^[[:space:]]*\)\(DocumentRoot\)\(.*\)|\1\2 "/shared/html"|' \
+    -e 's|<Directory "/var/www/html">|<Directory "/shared/html">|' \
+    -e 's|<Directory "/var/www">|<Directory "/shared">|' /etc/httpd/conf/httpd.conf
+
+# Log to std out/err
+sed -i -e 's%^ \+CustomLog.*%    CustomLog /dev/stderr combined%g' /etc/httpd/conf/httpd.conf
+sed -i -e 's%^ErrorLog.*%ErrorLog /dev/stderr%g' /etc/httpd/conf/httpd.conf
+
+/bin/runhealthcheck "httpd" "$HTTP_PORT" &>/dev/null &
+exec /usr/sbin/httpd -DFOREGROUND
+
+{{- end }}
+
+{{- if .Values.ironic.config_override.httpd }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: httpd-entrypoint
+data:
+  runhttpd.sh: |
+    {{- include "httpd-entrypoint" . | indent 4 }}
+{{- end }}

--- a/charts/baremetal-operator/templates/configmaps/entrypoints/init-bootstrap.tpl
+++ b/charts/baremetal-operator/templates/configmaps/entrypoints/init-bootstrap.tpl
@@ -1,0 +1,54 @@
+{{- define "init-bootstrap"}}
+#!/usr/bin/env bash
+set -xe
+
+mkdir -p /shared/{tftpboot,html/{images,pxelinux.cfg},log/{dnsmasq,httpd,ironic,ironic-inspector/ramdisk,mariadb}/}
+
+# Copy files to shared mount
+#cp /usr/lib/ipxe/undionly.kpxe /usr/lib/ipxe/ipxe.efi /shared/tftpboot
+#cp /tmp/inspector.ipxe /shared/html/inspector.ipxe
+#cp /tmp/dualboot.ipxe /shared/html/dualboot.ipxe
+
+# Remove log files from last deployment
+rm -rf /shared/log/httpd/*
+rm -rf /shared/log/ironic/*
+rm -rf /shared/log/ironic-inspector/*
+
+pushd /shared/html/images
+  declare -A ARTS
+  {{- range $key, $val := .Values.init_bootstrap.provisioning_files }}
+  ARTS[{{ $key | quote}}]={{ $val | quote }}
+  {{- end}}
+
+  for art in "${!ARTS[@]}"; do
+    if [ ! -f ${art} ] ; then
+        STATUSCODE=$(curl --silent --insecure --location --output ${art} --write-out "%{http_code}" ${ARTS[${art}]} )
+
+        if test $STATUSCODE -ne 200; then
+          echo "Failed to load ${ARTS[${art}]}"
+          exit 1
+        fi
+        if [[ ! "${art}" =~ \.tar$ ]] && [[ ! "${art}" =~ \.md5sum$ ]] && [[ ! "${!ARTS[@]}" =~ "${art}.md5sum" ]] ; then
+           md5sum "${art}" | awk '{print $1}' > "${art}.md5sum"
+        fi
+        if [[ "${art}" =~ \.tar$ ]]; then
+          tar -xf "${art}"
+        fi
+    fi
+  done
+popd
+chmod -R 0777 /shared/html
+
+touch /shared/init_finished
+{{- end }}
+
+{{- if .Values.init_bootstrap.enabled }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: init-bootstrap
+data:
+  init-bootstrap: |
+    {{- include "init-bootstrap" . | indent 4 }}
+{{- end }}

--- a/charts/baremetal-operator/templates/configmaps/entrypoints/inspector-entrypoint.tpl
+++ b/charts/baremetal-operator/templates/configmaps/entrypoints/inspector-entrypoint.tpl
@@ -1,0 +1,34 @@
+{{- define "inspector-entrypoint"}}
+#!/usr/bin/bash
+
+CONFIG=/etc/ironic-inspector/inspector.conf
+
+. /bin/ironic-common.sh
+
+wait_for_interface_or_ip
+
+# Remove log files from last deployment
+rm -rf /shared/log/ironic-inspector
+
+mkdir -p /shared/log/ironic-inspector
+
+cp $CONFIG $CONFIG.orig
+
+crudini --set $CONFIG ironic endpoint_override http://$IRONIC_URL_HOST:6385
+crudini --set $CONFIG service_catalog endpoint_override http://$IRONIC_URL_HOST:5050
+
+exec /usr/bin/ironic-inspector --config-file /etc/ironic-inspector/inspector-dist.conf \
+	--config-file /etc/ironic-inspector/inspector.conf \
+	--log-file /shared/log/ironic-inspector/ironic-inspector.log
+{{- end }}
+
+{{- if .Values.ironic.config_override.inspector }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: inspector-entrypoint
+data:
+  runironic-inspector.sh: |
+    {{- include "inspector-entrypoint" . | indent 4 }}
+{{- end }}

--- a/charts/baremetal-operator/templates/configmaps/entrypoints/inspector-entrypoint.tpl
+++ b/charts/baremetal-operator/templates/configmaps/entrypoints/inspector-entrypoint.tpl
@@ -12,10 +12,14 @@ rm -rf /shared/log/ironic-inspector
 
 mkdir -p /shared/log/ironic-inspector
 
-cp $CONFIG $CONFIG.orig
+if [ -f /cfg/inspector.conf ]; then
+    cp -f /cfg/inspector.conf /etc/ironic-inspector/inspector.conf
+else
+    cp $CONFIG $CONFIG.orig
 
-crudini --set $CONFIG ironic endpoint_override http://$IRONIC_URL_HOST:6385
-crudini --set $CONFIG service_catalog endpoint_override http://$IRONIC_URL_HOST:5050
+    crudini --set $CONFIG ironic endpoint_override http://$IRONIC_URL_HOST:6385
+    crudini --set $CONFIG service_catalog endpoint_override http://$IRONIC_URL_HOST:5050
+fi
 
 exec /usr/bin/ironic-inspector --config-file /etc/ironic-inspector/inspector-dist.conf \
 	--config-file /etc/ironic-inspector/inspector.conf \

--- a/charts/baremetal-operator/templates/configmaps/entrypoints/ironic-entrypoint.tpl
+++ b/charts/baremetal-operator/templates/configmaps/entrypoints/ironic-entrypoint.tpl
@@ -1,0 +1,30 @@
+{{- define "ironic-entrypoint"}}
+#!/usr/bin/bash
+
+. /bin/configure-ironic.sh
+
+ironic-dbsync --config-file /etc/ironic/ironic.conf upgrade
+
+# Remove log files from last deployment
+rm -rf /shared/log/ironic
+
+mkdir -p /shared/log/ironic
+
+/usr/bin/ironic-conductor &
+/usr/bin/ironic-api &
+
+/bin/runhealthcheck "ironic" &>/dev/null &
+
+sleep infinity
+{{- end }}
+
+{{- if .Values.ironic.config_override.ironic }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ironic-entrypoint
+data:
+  runironic.sh: |
+    {{- include "ironic-entrypoint" . | indent 4 }}
+{{- end }}

--- a/charts/baremetal-operator/templates/configmaps/entrypoints/ironic-entrypoint.tpl
+++ b/charts/baremetal-operator/templates/configmaps/entrypoints/ironic-entrypoint.tpl
@@ -1,7 +1,13 @@
 {{- define "ironic-entrypoint"}}
 #!/usr/bin/bash
 
-. /bin/configure-ironic.sh
+if [ -f /cfg/ironic.conf ]; then
+    cp -f /cfg/ironic.conf /etc/ironic/ironic.conf
+    mkdir -p /shared/html
+    mkdir -p /shared/ironic_prometheus_exporter
+else
+    . /bin/configure-ironic.sh
+fi
 
 ironic-dbsync --config-file /etc/ironic/ironic.conf upgrade
 

--- a/charts/baremetal-operator/templates/configmaps/entrypoints/mariadb-entrypoint.tpl
+++ b/charts/baremetal-operator/templates/configmaps/entrypoints/mariadb-entrypoint.tpl
@@ -1,0 +1,46 @@
+{{- define "mariadb-entrypoint"}}
+#!/usr/bin/bash
+PATH=$PATH:/usr/sbin/
+DATADIR="/var/lib/mysql"
+MARIADB_PASSWORD=${MARIADB_PASSWORD:-"change_me"}
+MARIADB_CONF_FILE="/etc/my.cnf.d/mariadb-server.cnf"
+
+ln -sf /proc/self/fd/1 /var/log/mariadb/mariadb.log
+
+if [ ! -d "${DATADIR}/mysql" ]; then
+    crudini --set "$MARIADB_CONF_FILE" mysqld max_connections 64
+    crudini --set "$MARIADB_CONF_FILE" mysqld max_heap_table_size 1M
+    crudini --set "$MARIADB_CONF_FILE" mysqld innodb_buffer_pool_size 5M
+    crudini --set "$MARIADB_CONF_FILE" mysqld innodb_log_buffer_size 512K
+
+    mysql_install_db --datadir="$DATADIR"
+
+    chown -R mysql "$DATADIR"
+
+    cat > /tmp/configure-mysql.sql <<-EOSQL
+DELETE FROM mysql.user ;
+CREATE USER 'ironic'@'localhost' identified by '${MARIADB_PASSWORD}' ;
+GRANT ALL on *.* TO 'ironic'@'localhost' WITH GRANT OPTION ;
+DROP DATABASE IF EXISTS test ;
+CREATE DATABASE IF NOT EXISTS  ironic ;
+FLUSH PRIVILEGES ;
+EOSQL
+
+    # mysqld_safe closes stdout/stderr if no bash options are set ($- == '')
+    # turn on tracing to prevent this
+    exec bash -x /usr/bin/mysqld_safe --init-file /tmp/configure-mysql.sql
+else
+    exec bash -x /usr/bin/mysqld_safe
+fi
+{{- end }}
+
+{{- if .Values.ironic.config_override.mariadb }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mariadb-entrypoint
+data:
+  runmariadb.sh: |
+    {{- include "mariadb-entrypoint" . | indent 4 }}
+{{- end }}

--- a/charts/baremetal-operator/templates/configmaps/entrypoints/mariadb-entrypoint.tpl
+++ b/charts/baremetal-operator/templates/configmaps/entrypoints/mariadb-entrypoint.tpl
@@ -8,11 +8,14 @@ MARIADB_CONF_FILE="/etc/my.cnf.d/mariadb-server.cnf"
 ln -sf /proc/self/fd/1 /var/log/mariadb/mariadb.log
 
 if [ ! -d "${DATADIR}/mysql" ]; then
-    crudini --set "$MARIADB_CONF_FILE" mysqld max_connections 64
-    crudini --set "$MARIADB_CONF_FILE" mysqld max_heap_table_size 1M
-    crudini --set "$MARIADB_CONF_FILE" mysqld innodb_buffer_pool_size 5M
-    crudini --set "$MARIADB_CONF_FILE" mysqld innodb_log_buffer_size 512K
-
+    if [ -f /cfg/my.cnf ]; then
+        cp -f /cfg/my.cnf $MARIADB_CONF_FILE
+    else
+        crudini --set "$MARIADB_CONF_FILE" mysqld max_connections 64
+        crudini --set "$MARIADB_CONF_FILE" mysqld max_heap_table_size 1M
+        crudini --set "$MARIADB_CONF_FILE" mysqld innodb_buffer_pool_size 5M
+        crudini --set "$MARIADB_CONF_FILE" mysqld innodb_log_buffer_size 512K
+    fi
     mysql_install_db --datadir="$DATADIR"
 
     chown -R mysql "$DATADIR"

--- a/charts/baremetal-operator/templates/files/dnsmasq.conf.tpl
+++ b/charts/baremetal-operator/templates/files/dnsmasq.conf.tpl
@@ -9,7 +9,7 @@ tftp-root=/shared/tftpboot
 # Disable listening for DNS
 port=0
 
-dhcp-range={{ .Values.ironic.configuration.dhcp_range }}
+dhcp-range={{ .Values.dnsmasq.dhcp_range }}
 
 # Disable default router(s) and DNS over provisioning network
 dhcp-option=3
@@ -42,7 +42,7 @@ dhcp-option=tag:pxe6,option6:bootfile-url,tftp://{{ .Values.ironic.configuration
 dhcp-option=tag:ipxe6,option6:bootfile-url,http://{{ .Values.ironic.configuration.provisioning_ip }}:{{ .Values.ironic.configuration.http_port }}/dualboot.ipxe
 {{- end }}
 
-{{- range $iface := split "," .Values.ironic.configuration.dnsmasq_except_interface }}
+{{- range $iface := split "," .Values.dnsmasq.except_interface }}
 except-interface={{- $iface }}
 {{- end }}
 

--- a/charts/baremetal-operator/templates/files/dnsmasq.conf.tpl
+++ b/charts/baremetal-operator/templates/files/dnsmasq.conf.tpl
@@ -1,0 +1,61 @@
+{{- define "dnsmasq.conf" }}
+
+interface={{ .Values.ironic.configuration.provisioning_interface }}
+bind-dynamic
+log-dhcp
+enable-tftp
+tftp-root=/shared/tftpboot
+
+# Disable listening for DNS
+port=0
+
+dhcp-range={{ .Values.ironic.configuration.dhcp_range }}
+
+# Disable default router(s) and DNS over provisioning network
+dhcp-option=3
+dhcp-option=6
+
+{{- if eq .Values.ironic.configuration.ipv "4" }}
+
+# IPv4 Configuration:
+dhcp-match=ipxe,175
+# Client is already running iPXE; move to next stage of chainloading
+dhcp-boot=tag:ipxe,http://{{ .Values.ironic.configuration.provisioning_ip }}:{{ .Values.ironic.configuration.http_port }}/dualboot.ipxe
+
+# Note: Need to test EFI booting
+dhcp-match=set:efi,option:client-arch,7
+dhcp-match=set:efi,option:client-arch,9
+dhcp-match=set:efi,option:client-arch,11
+# Client is PXE booting over EFI without iPXE ROM; send EFI version of iPXE chainloader
+dhcp-boot=tag:efi,tag:!ipxe,ipxe.efi
+
+# Client is running PXE over BIOS; send BIOS version of iPXE chainloader
+dhcp-boot=/undionly.kpxe,{{ .Values.ironic.configuration.provisioning_ip }}
+
+{{ else }}
+# IPv6 Configuration:
+enable-ra
+ra-param={{ .Values.ironic.configuration.provisioning_interface }},10
+dhcp-vendorclass=set:pxe6,enterprise:343,PXEClient
+dhcp-userclass=set:ipxe6,iPXE
+dhcp-option=tag:pxe6,option6:bootfile-url,tftp://{{ .Values.ironic.configuration.provisioning_ip }}/snponly.efi
+dhcp-option=tag:ipxe6,option6:bootfile-url,http://{{ .Values.ironic.configuration.provisioning_ip }}:{{ .Values.ironic.configuration.http_port }}/dualboot.ipxe
+{{- end }}
+
+{{- range $iface := split "," .Values.ironic.configuration.dnsmasq_except_interface }}
+except-interface={{- $iface }}
+{{- end }}
+
+{{- end }}
+
+{{- if .Values.ironic.config_override.dnsmasq }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dnsmasq-config
+data:
+  dnsmasq.conf: |
+    {{- include "dnsmasq.conf" . | indent 4 }}
+{{- end }}
+

--- a/charts/baremetal-operator/templates/files/dualboot.ipxe.tpl
+++ b/charts/baremetal-operator/templates/files/dualboot.ipxe.tpl
@@ -1,0 +1,35 @@
+{{- define "dualboot.ipxe" }}
+#!ipxe
+
+# NOTE(lucasagomes): Loop over all network devices and boot from
+# the first one capable of booting. For more information see:
+# https://bugs.launchpad.net/ironic/+bug/1504482
+set netid:int32 -1
+:loop
+inc netid
+isset ${net${netid}/mac} || chain pxelinux.cfg/${mac:hexhyp} || goto inspector
+echo Attempting to boot from MAC ${net${netid}/mac:hexhyp}
+chain pxelinux.cfg/${net${netid}/mac:hexhyp} || goto loop
+
+# If no networks configured to boot then introspect first valid one
+:inspector
+chain inspector.ipxe || goto loop_done
+
+:loop_done
+echo PXE boot failed! No configuration found for any of the present NICs
+echo and could not find inspector.ipxe to use as fallback.
+echo Press any key to reboot...
+prompt --timeout 180
+reboot
+{{- end }}
+
+{{- if .Values.ironic.config_override.dualboot_ipxe }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dualboot-ipxe-config
+data:
+  dualboot.ipxe: |
+    {{- include "dualboot.ipxe" . | indent 4 }}
+{{- end }}

--- a/charts/baremetal-operator/templates/files/httpd.conf.tpl
+++ b/charts/baremetal-operator/templates/files/httpd.conf.tpl
@@ -1,0 +1,73 @@
+{{- define "httpd.conf" }}
+ServerRoot "/etc/httpd"
+Listen [::]:{{ .Values.ironic.configuration.http_port }}
+Include conf.modules.d/*.conf
+User apache
+Group apache
+ServerAdmin root@localhost
+<Directory />
+    AllowOverride none
+    Require all denied
+</Directory>
+DocumentRoot "/shared/html"
+<Directory "/shared">
+    AllowOverride None
+    Require all granted
+</Directory>
+<Directory "/shared/html">
+    Options Indexes FollowSymLinks
+    AllowOverride None
+    Require all granted
+</Directory>
+<IfModule dir_module>
+    DirectoryIndex index.html
+</IfModule>
+<Files ".ht*">
+    Require all denied
+</Files>
+ErrorLog /dev/stderr
+LogLevel warn
+<IfModule log_config_module>
+    LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
+    LogFormat "%h %l %u %t \"%r\" %>s %b" common
+    <IfModule logio_module>
+      # You need to enable mod_logio.c to use %I and %O
+      LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" %I %O" combinedio
+    </IfModule>
+    CustomLog /dev/stderr combined
+</IfModule>
+<IfModule alias_module>
+    ScriptAlias /cgi-bin/ "/var/www/cgi-bin/"
+</IfModule>
+<Directory "/var/www/cgi-bin">
+    AllowOverride None
+    Options None
+    Require all granted
+</Directory>
+<IfModule mime_module>
+    TypesConfig /etc/mime.types
+    AddType application/x-compress .Z
+    AddType application/x-gzip .gz .tgz
+    AddType text/html .shtml
+    AddOutputFilter INCLUDES .shtml
+</IfModule>
+AddDefaultCharset UTF-8
+<IfModule mime_magic_module>
+    MIMEMagicFile conf/magic
+</IfModule>
+EnableSendfile on
+IncludeOptional conf.d/*.conf
+
+{{- end }}
+
+{{- if .Values.ironic.config_override.httpd }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: httpd-config
+data:
+  httpd.conf: |
+    {{- include "httpd.conf" . | indent 4 }}
+{{- end }}
+

--- a/charts/baremetal-operator/templates/files/inspector.conf.tpl
+++ b/charts/baremetal-operator/templates/files/inspector.conf.tpl
@@ -1,0 +1,39 @@
+{{- define "inspector.conf" }}
+[DEFAULT]
+auth_strategy = noauth
+debug = true
+transport_url = fake://
+use_stderr = true
+listen_address = ::
+[database]
+connection = sqlite:///var/lib/ironic-inspector/ironic-inspector.db
+[discovery]
+enroll_node_driver = ipmi
+[ironic]
+auth_type = none
+endpoint_override = http://{{ .Values.ironic.configuration.provisioning_ip }}:6385
+[processing]
+always_store_ramdisk_logs = true
+node_not_found_hook = enroll
+permit_active_introspection = true
+power_off = false
+processing_hooks = $default_processing_hooks,extra_hardware,lldp_basic
+ramdisk_logs_dir = /shared/log/ironic-inspector/ramdisk
+store_data = database
+[pxe_filter]
+driver = noop
+[service_catalog]
+auth_type = none
+endpoint_override = http://{{ .Values.ironic.configuration.provisioning_ip }}:5050
+{{- end }}
+
+{{- if .Values.ironic.config_override.inspector }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: inspector-config
+data:
+  inspector.conf: |
+    {{- include "inspector.conf" . | indent 4 }}
+{{- end }}

--- a/charts/baremetal-operator/templates/files/inspector.ipxe.tpl
+++ b/charts/baremetal-operator/templates/files/inspector.ipxe.tpl
@@ -1,0 +1,22 @@
+{{- define "inspector.ipxe" }}
+#!ipxe
+
+:retry_boot
+echo In inspector.ipxe
+imgfree
+# NOTE(dtantsur): keep inspection kernel params in [mdns]params in ironic-inspector-image
+kernel --timeout 60000 http://{{ .Values.ironic.configuration.provisioning_ip }}:{{ .Values.ironic.configuration.http_port }}/images/ironic-python-agent.kernel ipa-inspection-callback-url=http://{{ .Values.ironic.configuration.provisioning_ip }}:5050/v1/continue ipa-inspection-collectors=default,extra-hardware,logs systemd.journald.forward_to_console=yes BOOTIF=${mac} ipa-debug=1 ipa-inspection-dhcp-all-interfaces=1 ipa-collect-lldp=1 initrd=ironic-python-agent.initramfs || goto retry_boot
+initrd --timeout 60000 http://{{ .Values.ironic.configuration.provisioning_ip }}:{{ .Values.ironic.configuration.http_port }}/images/ironic-python-agent.initramfs || goto retry_boot
+boot
+{{- end }}
+
+{{- if .Values.ironic.config_override.inspector_ipxe }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: inspector-ipxe-config
+data:
+  inspector.ipxe: |
+    {{- include "inspector.ipxe" . | indent 4 }}
+{{- end }}

--- a/charts/baremetal-operator/templates/files/ironic.conf.tpl
+++ b/charts/baremetal-operator/templates/files/ironic.conf.tpl
@@ -30,7 +30,7 @@ send_sensor_data_interval = 160
 api_url = http://{{ .Values.ironic.configuration.provisioning_ip }}:6385
 bootloader = http://{{ .Values.ironic.configuration.provisioning_ip }}:{{ .Values.ironic.configuration.http_port }}/uefi_esp.img
 [database]
-connection = mysql+pymysql://ironic:{{- .Values.ironic.configuration.mariadb_password }}@localhost/ironic?charset=utf8
+connection = mysql+pymysql://ironic:{{- .Values.mariadb.password }}@localhost/ironic?charset=utf8
 [deploy]
 default_boot_option = local
 erase_devices_metadata_priority = 10

--- a/charts/baremetal-operator/templates/files/ironic.conf.tpl
+++ b/charts/baremetal-operator/templates/files/ironic.conf.tpl
@@ -1,0 +1,70 @@
+{{- define "ironic.conf" }}
+[DEFAULT]
+auth_strategy = noauth
+my_ip = {{ .Values.ironic.configuration.provisioning_ip }}
+debug = true
+default_boot_interface = ipxe
+default_deploy_interface = direct
+default_inspect_interface = inspector
+default_network_interface = noop
+enabled_boot_interfaces = pxe,ipxe,fake,redfish-virtual-media
+enabled_deploy_interfaces = direct,fake
+enabled_hardware_types = ipmi,idrac,irmc,fake-hardware,redfish
+enabled_inspect_interfaces = inspector,idrac,irmc,fake,redfish
+enabled_management_interfaces = ipmitool,idrac,irmc,fake,redfish,idrac-redfish
+enabled_power_interfaces = ipmitool,idrac,irmc,fake,redfish,idrac-redfish
+enabled_raid_interfaces = no-raid,irmc,agent,fake
+enabled_vendor_interfaces = ipmitool,no-vendor,idrac,fake
+rpc_transport = json-rpc
+use_stderr = true
+[agent]
+deploy_logs_collect = always
+deploy_logs_local_path = /shared/log/ironic/deploy
+[api]
+host_ip = ::
+api_workers = {{ .Values.ironic.configuration.api_workers }}
+[conductor]
+automated_clean = {{ .Values.ironic.configuration.automated_clean }}
+send_sensor_data = true
+send_sensor_data_interval = 160
+api_url = http://{{ .Values.ironic.configuration.provisioning_ip }}:6385
+bootloader = http://{{ .Values.ironic.configuration.provisioning_ip }}:{{ .Values.ironic.configuration.http_port }}/uefi_esp.img
+[database]
+connection = mysql+pymysql://ironic:{{- .Values.ironic.configuration.mariadb_password }}@localhost/ironic?charset=utf8
+[deploy]
+default_boot_option = local
+erase_devices_metadata_priority = 10
+erase_devices_priority = 0
+http_root = /shared/html/
+http_url = http://{{ .Values.ironic.configuration.provisioning_ip }}:{{ .Values.ironic.configuration.http_port }}
+fast_track = {{ .Values.ironic.configuration.fast_track }}
+[dhcp]
+dhcp_provider = none
+[inspector]
+endpoint_override = http://{{ .Values.ironic.configuration.provisioning_ip }}:5050
+[oslo_messaging_notifications]
+driver = prometheus_exporter
+location = /shared/ironic_prometheus_exporter
+transport_url = fake://
+[pxe]
+images_path = /shared/html/tmp
+instance_master_path = /shared/html/master_images
+ipxe_enabled = true
+pxe_config_template = $pybasedir/drivers/modules/ipxe_config.template
+tftp_master_path = /shared/tftpboot
+tftp_root = /shared/tftpboot
+uefi_pxe_config_template = $pybasedir/drivers/modules/ipxe_config.template
+[redfish]
+use_swift = false
+{{- end }}
+
+{{- if .Values.ironic.config_override.ironic }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ironic-config
+data:
+  ironic.conf: |
+    {{- include "ironic.conf" . | indent 4 }}
+{{- end }}

--- a/charts/baremetal-operator/templates/files/my.cnf.tpl
+++ b/charts/baremetal-operator/templates/files/my.cnf.tpl
@@ -1,0 +1,34 @@
+{{- define "my.cnf" }}
+[server]
+
+[mysqld]
+datadir=/var/lib/mysql
+socket=/var/lib/mysql/mysql.sock
+log-error=/var/log/mariadb/mariadb.log
+pid-file=/run/mariadb/mariadb.pid
+max_connections = 64
+max_heap_table_size = 1M
+innodb_buffer_pool_size = 5M
+innodb_log_buffer_size = 512K
+
+[galera]
+
+[embedded]
+
+[mariadb]
+
+[mariadb-10.3]
+
+{{- end }}
+
+{{- if .Values.ironic.config_override.mariadb }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mariadb-config
+data:
+  my.cnf: |
+    {{- include "my.cnf" . | indent 4 }}
+
+{{- end }}

--- a/charts/baremetal-operator/templates/ironic-pv.yaml
+++ b/charts/baremetal-operator/templates/ironic-pv.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.persistence.hostPath.enabled }}
 ---
 kind: PersistentVolume
 apiVersion: v1
@@ -9,12 +10,12 @@ metadata:
 spec:
   storageClassName: default
   capacity:
-    storage: {{ .Values.ironic.ironic_storage.volume_capacity }}
+    storage: {{ .Values.persistence.volume_capacity }}
   accessModes:
     - ReadWriteOnce
   hostPath:
-    path: {{ .Values.ironic.ironic_storage.hostPath }}
-
+    path: {{ .Values.persistence.hostPath.path }}
+{{- end }}
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1
@@ -22,9 +23,10 @@ metadata:
   name: ironic-pv-claim
   namespace: {{ .Values.namespace }}
 spec:
-  storageClassName: default
+
+  storageClassName: {{ .Values.persistence.storageClassName }}
   accessModes:
     - ReadWriteOnce
   resources:
     requests:
-      storage: {{ .Values.ironic.ironic_storage.volume_capacity }}
+      storage: {{ .Values.persistence.volume_capacity }}

--- a/charts/baremetal-operator/templates/ironic.yaml
+++ b/charts/baremetal-operator/templates/ironic.yaml
@@ -25,6 +25,12 @@ spec:
             name: dnsmasq-entrypoint
             defaultMode: 0700
         {{- end }}
+        {{- if .Values.ironic.config_override.httpd }}
+        - name: httpd-entrypoint
+          configMap:
+            name: httpd-entrypoint
+            defaultMode: 0700
+        {{- end }}
       {{- with .Values.ironic.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -65,6 +71,11 @@ spec:
           volumeMounts:
               - mountPath: "/shared"
                 name: ironic-storage
+              {{- if .Values.ironic.config_override.httpd }}
+              - name: httpd-entrypoint
+                mountPath: /bin/runhttpd
+                subPath: runhttpd.sh
+              {{- end }}
         - name: mariadb
           image: {{ .Values.ironic.images.ironic_aio }}
           command: ["/bin/runmariadb"]

--- a/charts/baremetal-operator/templates/ironic.yaml
+++ b/charts/baremetal-operator/templates/ironic.yaml
@@ -50,6 +50,10 @@ spec:
           configMap:
             name: mariadb-entrypoint
             defaultMode: 0700
+        - name: mariadb-config
+          configMap:
+            name: mariadb-config
+            defaultMode: 0700
         {{- end }}
         {{- if .Values.ironic.config_override.ironic }}
         - name: ironic-entrypoint
@@ -149,6 +153,9 @@ spec:
             - name: mariadb-entrypoint
               mountPath: /bin/runmariadb
               subPath: runmariadb.sh
+            - name: mariadb-config
+              mountPath: /cfg/my.cnf
+              subPath: my.cnf
               {{- end }}
         - name: ironic
           image: {{ .Values.ironic.images.ironic_aio }}

--- a/charts/baremetal-operator/templates/ironic.yaml
+++ b/charts/baremetal-operator/templates/ironic.yaml
@@ -43,6 +43,12 @@ spec:
             name: ironic-entrypoint
             defaultMode: 0700
         {{- end }}
+        {{- if .Values.ironic.config_override.inspector }}
+        - name: inspector-entrypoint
+          configMap:
+            name: inspector-entrypoint
+            defaultMode: 0700
+        {{- end }}
       {{- with .Values.ironic.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -131,6 +137,7 @@ spec:
             {{- end }}
         - name: ironic-inspector
           image: {{ .Values.ironic.images.ironic_inspector }}
+          command: ["/bin/runironic-inspector"]
           securityContext:
             privileged: true
           env:
@@ -139,3 +146,9 @@ spec:
           volumeMounts:
             - mountPath: "/shared"
               name: ironic-storage
+            {{- if .Values.ironic.config_override.inspector }}
+            - name: inspector-entrypoint
+              mountPath: /bin/runironic-inspector
+              subPath: runironic-inspector.sh
+            {{- end }}
+

--- a/charts/baremetal-operator/templates/ironic.yaml
+++ b/charts/baremetal-operator/templates/ironic.yaml
@@ -87,7 +87,7 @@ spec:
       {{- end }}
       containers:
         - name: dnsmasq
-          image: {{ .Values.ironic.images.ironic_aio }}
+          image: {{ .Values.ironic.image.fullName }}
           command: ["/bin/rundnsmasq"]
           securityContext:
             privileged: true
@@ -112,7 +112,7 @@ spec:
                 subPath: dnsmasq.conf
               {{- end }}
         - name: httpd
-          image: {{ .Values.ironic.images.ironic_aio }}
+          image: {{ .Values.ironic.image.fullName }}
           command: ["/bin/runhttpd"]
           securityContext:
             privileged: true
@@ -145,7 +145,7 @@ spec:
                 subPath: dualboot.ipxe
               {{- end }}
         - name: mariadb
-          image: {{ .Values.ironic.images.ironic_aio }}
+          image: {{ .Values.ironic.image.fullName }}
           command: ["/bin/runmariadb"]
           securityContext:
             privileged: true
@@ -169,7 +169,7 @@ spec:
               subPath: my.cnf
               {{- end }}
         - name: ironic
-          image: {{ .Values.ironic.images.ironic_aio }}
+          image: {{ .Values.ironic.image.fullName }}
           command: ["/bin/runironic"]
           securityContext:
             privileged: true
@@ -192,7 +192,7 @@ spec:
               subPath: ironic.conf
             {{- end }}
         - name: ironic-inspector
-          image: {{ .Values.ironic.images.ironic_inspector }}
+          image: {{ .Values.ironic_inspector.image.fullName }}
           command: ["/bin/runironic-inspector"]
           securityContext:
             privileged: true

--- a/charts/baremetal-operator/templates/ironic.yaml
+++ b/charts/baremetal-operator/templates/ironic.yaml
@@ -31,13 +31,13 @@ spec:
             privileged: true
           env:
             - name: PROVISIONING_INTERFACE
-              value: {{ .Values.ironic.ironic_conf.provisioning_interface }}
+              value: {{ .Values.ironic.configuration.provisioning_interface }}
             - name: HTTP_PORT
-              value: {{ .Values.ironic.ironic_conf.http_port | quote }}
+              value: {{ .Values.ironic.configuration.http_port | quote }}
             - name: DHCP_RANGE
-              value: {{ .Values.ironic.ironic_conf.dhcp_range }}
+              value: {{ .Values.ironic.configuration.dhcp_range }}
             - name: DNSMASQ_EXCEPT_INTERFACE
-              value: {{ .Values.ironic.ironic_conf.dnsmasq_except_interface }}
+              value: {{ .Values.ironic.configuration.dnsmasq_except_interface }}
           volumeMounts:
               - mountPath: "/shared"
                 name: ironic-storage
@@ -48,9 +48,9 @@ spec:
             privileged: true
           env:
             - name: PROVISIONING_INTERFACE
-              value: {{ .Values.ironic.ironic_conf.provisioning_interface }}
+              value: {{ .Values.ironic.configuration.provisioning_interface }}
             - name: HTTP_PORT
-              value: {{ .Values.ironic.ironic_conf.http_port | quote }}
+              value: {{ .Values.ironic.configuration.http_port | quote }}
           volumeMounts:
               - mountPath: "/shared"
                 name: ironic-storage
@@ -61,9 +61,9 @@ spec:
             privileged: true
           env:
             - name: MARIADB_PASSWORD
-              value: {{ .Values.ironic.ironic_conf.mariadb_password }}
+              value: {{ .Values.ironic.configuration.mariadb_password }}
             - name: PROVISIONING_INTERFACE
-              value: {{ .Values.ironic.ironic_conf.provisioning_interface }}
+              value: {{ .Values.ironic.configuration.provisioning_interface }}
           volumeMounts:
             - mountPath: "/shared"
               name: ironic-storage
@@ -76,11 +76,11 @@ spec:
             privileged: true
           env:
             - name: MARIADB_PASSWORD
-              value: {{ .Values.ironic.ironic_conf.mariadb_password }}
+              value: {{ .Values.ironic.configuration.mariadb_password }}
             - name: PROVISIONING_INTERFACE
-              value: {{ .Values.ironic.ironic_conf.provisioning_interface }}
+              value: {{ .Values.ironic.configuration.provisioning_interface }}
             - name: HTTP_PORT
-              value: {{ .Values.ironic.ironic_conf.http_port | quote }}
+              value: {{ .Values.ironic.configuration.http_port | quote }}
           volumeMounts:
             - mountPath: "/shared"
               name: ironic-storage
@@ -90,7 +90,7 @@ spec:
             privileged: true
           env:
             - name: PROVISIONING_INTERFACE
-              value: {{ .Values.ironic.ironic_conf.provisioning_interface }}
+              value: {{ .Values.ironic.configuration.provisioning_interface }}
           volumeMounts:
             - mountPath: "/shared"
               name: ironic-storage

--- a/charts/baremetal-operator/templates/ironic.yaml
+++ b/charts/baremetal-operator/templates/ironic.yaml
@@ -56,6 +56,10 @@ spec:
           configMap:
             name: ironic-entrypoint
             defaultMode: 0700
+        - name: ironic-config
+          configMap:
+            name: ironic-config
+            defaultMode: 0700
         {{- end }}
         {{- if .Values.ironic.config_override.inspector }}
         - name: inspector-entrypoint
@@ -165,6 +169,9 @@ spec:
             - name: ironic-entrypoint
               mountPath: /bin/runironic
               subPath: runironic.sh
+            - name: ironic-config
+              mountPath: /cfg/ironic.conf
+              subPath: ironic.conf
             {{- end }}
         - name: ironic-inspector
           image: {{ .Values.ironic.images.ironic_inspector }}

--- a/charts/baremetal-operator/templates/ironic.yaml
+++ b/charts/baremetal-operator/templates/ironic.yaml
@@ -31,6 +31,12 @@ spec:
             name: httpd-entrypoint
             defaultMode: 0700
         {{- end }}
+        {{- if .Values.ironic.config_override.mariadb }}
+        - name: mariadb-entrypoint
+          configMap:
+            name: mariadb-entrypoint
+            defaultMode: 0700
+        {{- end }}
       {{- with .Values.ironic.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -92,6 +98,11 @@ spec:
             - mountPath: "/var/lib/mysql"
               name: ironic-storage
               subPath: mysql
+              {{- if .Values.ironic.config_override.mariadb }}
+            - name: mariadb-entrypoint
+              mountPath: /bin/runmariadb
+              subPath: runmariadb.sh
+              {{- end }}
         - name: ironic
           image: {{ .Values.ironic.images.ironic_aio }}
           securityContext:

--- a/charts/baremetal-operator/templates/ironic.yaml
+++ b/charts/baremetal-operator/templates/ironic.yaml
@@ -145,13 +145,13 @@ spec:
                 subPath: dualboot.ipxe
               {{- end }}
         - name: mariadb
-          image: {{ .Values.ironic.image.fullName }}
+          image: {{ .Values.mariadb.image.fullName }}
           command: ["/bin/runmariadb"]
           securityContext:
             privileged: true
           env:
             - name: MARIADB_PASSWORD
-              value: {{ .Values.ironic.configuration.mariadb_password }}
+              value: {{ .Values.mariadb.password }}
             - name: PROVISIONING_INTERFACE
               value: {{ .Values.ironic.configuration.provisioning_interface }}
           volumeMounts:
@@ -175,7 +175,7 @@ spec:
             privileged: true
           env:
             - name: MARIADB_PASSWORD
-              value: {{ .Values.ironic.configuration.mariadb_password }}
+              value: {{ .Values.mariadb.password }}
             - name: PROVISIONING_INTERFACE
               value: {{ .Values.ironic.configuration.provisioning_interface }}
             - name: HTTP_PORT

--- a/charts/baremetal-operator/templates/ironic.yaml
+++ b/charts/baremetal-operator/templates/ironic.yaml
@@ -24,6 +24,10 @@ spec:
           configMap:
             name: dnsmasq-entrypoint
             defaultMode: 0700
+        - name: dnsmasq-config
+          configMap:
+            name: dnsmasq-config
+            defaultMode: 0700
         {{- end }}
         {{- if .Values.ironic.config_override.httpd }}
         - name: httpd-entrypoint
@@ -75,6 +79,9 @@ spec:
               - name: dnsmasq-entrypoint
                 mountPath: /bin/rundnsmasq
                 subPath: rundnsmasq.sh
+              - name: dnsmasq-config
+                mountPath: /cfg/dnsmasq.conf
+                subPath: dnsmasq.conf
               {{- end }}
         - name: httpd
           image: {{ .Values.ironic.images.ironic_aio }}

--- a/charts/baremetal-operator/templates/ironic.yaml
+++ b/charts/baremetal-operator/templates/ironic.yaml
@@ -87,7 +87,7 @@ spec:
       {{- end }}
       containers:
         - name: dnsmasq
-          image: {{ .Values.ironic.image.fullName }}
+          image: {{ .Values.dnsmasq.image.fullName }}
           command: ["/bin/rundnsmasq"]
           securityContext:
             privileged: true
@@ -97,9 +97,9 @@ spec:
             - name: HTTP_PORT
               value: {{ .Values.ironic.configuration.http_port | quote }}
             - name: DHCP_RANGE
-              value: {{ .Values.ironic.configuration.dhcp_range }}
+              value: {{ .Values.dnsmasq.dhcp_range }}
             - name: DNSMASQ_EXCEPT_INTERFACE
-              value: {{ .Values.ironic.configuration.dnsmasq_except_interface }}
+              value: {{ .Values.dnsmasq.except_interface | quote }}
           volumeMounts:
               - mountPath: "/shared"
                 name: ironic-storage

--- a/charts/baremetal-operator/templates/ironic.yaml
+++ b/charts/baremetal-operator/templates/ironic.yaml
@@ -19,6 +19,12 @@ spec:
         - name: ironic-storage
           persistentVolumeClaim:
            claimName: ironic-pv-claim
+        {{- if .Values.ironic.config_override.dnsmasq }}
+        - name: dnsmasq-entrypoint
+          configMap:
+            name: dnsmasq-entrypoint
+            defaultMode: 0700
+        {{- end }}
       {{- with .Values.ironic.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -41,6 +47,11 @@ spec:
           volumeMounts:
               - mountPath: "/shared"
                 name: ironic-storage
+              {{- if .Values.ironic.config_override.dnsmasq }}
+              - name: dnsmasq-entrypoint
+                mountPath: /bin/rundnsmasq
+                subPath: rundnsmasq.sh
+              {{- end }}
         - name: httpd
           image: {{ .Values.ironic.images.ironic_aio }}
           command: ["/bin/runhttpd"]

--- a/charts/baremetal-operator/templates/ironic.yaml
+++ b/charts/baremetal-operator/templates/ironic.yaml
@@ -37,6 +37,12 @@ spec:
             name: mariadb-entrypoint
             defaultMode: 0700
         {{- end }}
+        {{- if .Values.ironic.config_override.ironic }}
+        - name: ironic-entrypoint
+          configMap:
+            name: ironic-entrypoint
+            defaultMode: 0700
+        {{- end }}
       {{- with .Values.ironic.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -105,6 +111,7 @@ spec:
               {{- end }}
         - name: ironic
           image: {{ .Values.ironic.images.ironic_aio }}
+          command: ["/bin/runironic"]
           securityContext:
             privileged: true
           env:
@@ -117,6 +124,11 @@ spec:
           volumeMounts:
             - mountPath: "/shared"
               name: ironic-storage
+            {{- if .Values.ironic.config_override.ironic }}
+            - name: ironic-entrypoint
+              mountPath: /bin/runironic
+              subPath: runironic.sh
+            {{- end }}
         - name: ironic-inspector
           image: {{ .Values.ironic.images.ironic_inspector }}
           securityContext:

--- a/charts/baremetal-operator/templates/ironic.yaml
+++ b/charts/baremetal-operator/templates/ironic.yaml
@@ -39,6 +39,12 @@ spec:
             name: httpd-config
             defaultMode: 0700
         {{- end }}
+        {{- if .Values.ironic.config_override.inspector_ipxe }}
+        - name: inspector-ipxe-config
+          configMap:
+            name: inspector-ipxe-config
+            defaultMode: 0644
+        {{- end }}
         {{- if .Values.ironic.config_override.mariadb }}
         - name: mariadb-entrypoint
           configMap:
@@ -100,13 +106,20 @@ spec:
           volumeMounts:
               - mountPath: "/shared"
                 name: ironic-storage
-              {{- if .Values.ironic.config_override.httpd }}
+              {{- if or .Values.ironic.config_override.httpd .Values.ironic.config_override.inspector_ipxe }}
               - name: httpd-entrypoint
                 mountPath: /bin/runhttpd
                 subPath: runhttpd.sh
+              {{- end }}
+              {{- if .Values.ironic.config_override.httpd }}
               - name: httpd-config
                 mountPath: /cfg/httpd.conf
                 subPath: httpd.conf
+              {{- end }}
+              {{- if .Values.ironic.config_override.inspector_ipxe }}
+              - name: inspector-ipxe-config
+                mountPath: /cfg/inspector.ipxe
+                subPath: inspector.ipxe
               {{- end }}
         - name: mariadb
           image: {{ .Values.ironic.images.ironic_aio }}

--- a/charts/baremetal-operator/templates/ironic.yaml
+++ b/charts/baremetal-operator/templates/ironic.yaml
@@ -34,6 +34,10 @@ spec:
           configMap:
             name: httpd-entrypoint
             defaultMode: 0700
+        - name: httpd-config
+          configMap:
+            name: httpd-config
+            defaultMode: 0700
         {{- end }}
         {{- if .Values.ironic.config_override.mariadb }}
         - name: mariadb-entrypoint
@@ -100,6 +104,9 @@ spec:
               - name: httpd-entrypoint
                 mountPath: /bin/runhttpd
                 subPath: runhttpd.sh
+              - name: httpd-config
+                mountPath: /cfg/httpd.conf
+                subPath: httpd.conf
               {{- end }}
         - name: mariadb
           image: {{ .Values.ironic.images.ironic_aio }}

--- a/charts/baremetal-operator/templates/ironic.yaml
+++ b/charts/baremetal-operator/templates/ironic.yaml
@@ -62,6 +62,10 @@ spec:
           configMap:
             name: inspector-entrypoint
             defaultMode: 0700
+        - name: inspector-config
+          configMap:
+            name: inspector-config
+            defaultMode: 0700
         {{- end }}
       {{- with .Values.ironic.nodeSelector }}
       nodeSelector:
@@ -177,5 +181,8 @@ spec:
             - name: inspector-entrypoint
               mountPath: /bin/runironic-inspector
               subPath: runironic-inspector.sh
+            - name: inspector-config
+              mountPath: /cfg/inspector.conf
+              subPath: inspector.conf
             {{- end }}
 

--- a/charts/baremetal-operator/templates/ironic.yaml
+++ b/charts/baremetal-operator/templates/ironic.yaml
@@ -81,9 +81,28 @@ spec:
             name: dualboot-ipxe-config
             defaultMode: 0644
         {{- end }}
+        {{- if .Values.init_bootstrap.enabled }}
+        - name: init-bootstrap
+          configMap:
+            name: init-bootstrap
+            defaultMode: 0700
+        {{- end }}
       {{- with .Values.ironic.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.init_bootstrap.enabled }}
+      initContainers:
+        - name: init-bootstrap
+          image: {{ .Values.init_bootstrap.image.fullName }}
+          imagePullPolicy: {{ .Values.init_bootstrap.image.pullPolicy }}
+          command: ['/bin/init-bootstrap']
+          volumeMounts:
+            - name: ironic-storage
+              mountPath: "/shared"
+            - name: init-bootstrap
+              mountPath: /bin/init-bootstrap
+              subPath: init-bootstrap
       {{- end }}
       containers:
         - name: dnsmasq

--- a/charts/baremetal-operator/templates/ironic.yaml
+++ b/charts/baremetal-operator/templates/ironic.yaml
@@ -112,7 +112,7 @@ spec:
                 subPath: dnsmasq.conf
               {{- end }}
         - name: httpd
-          image: {{ .Values.ironic.image.fullName }}
+          image: {{ .Values.httpd.image.fullName }}
           command: ["/bin/runhttpd"]
           securityContext:
             privileged: true

--- a/charts/baremetal-operator/templates/ironic.yaml
+++ b/charts/baremetal-operator/templates/ironic.yaml
@@ -75,6 +75,12 @@ spec:
             name: inspector-config
             defaultMode: 0700
         {{- end }}
+        {{- if .Values.ironic.config_override.dualboot_ipxe }}
+        - name: dualboot-ipxe-config
+          configMap:
+            name: dualboot-ipxe-config
+            defaultMode: 0644
+        {{- end }}
       {{- with .Values.ironic.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -132,6 +138,11 @@ spec:
               - name: inspector-ipxe-config
                 mountPath: /cfg/inspector.ipxe
                 subPath: inspector.ipxe
+              {{- end }}
+              {{- if .Values.ironic.config_override.dualboot_ipxe }}
+              - name: dualboot-ipxe-config
+                mountPath: /tmp/dualboot.ipxe
+                subPath: dualboot.ipxe
               {{- end }}
         - name: mariadb
           image: {{ .Values.ironic.images.ironic_aio }}

--- a/charts/baremetal-operator/templates/operator.yaml
+++ b/charts/baremetal-operator/templates/operator.yaml
@@ -35,7 +35,7 @@ spec:
             - name: OPERATOR_NAME
               value: "baremetal-operator"
             - name: DEPLOY_KERNEL_URL
-              value: "{{ .Values.operator.deploy_kernel_url }}"
+              value: "http://{{- .Values.ironic.configuration.provisioning_ip }}/{{- .Values.operator.deploy_kernel_path }}"
             - name: DEPLOY_RAMDISK_URL
               value: "{{ .Values.operator.deploy_ramdisk_url }}"
             - name: IRONIC_ENDPOINT

--- a/charts/baremetal-operator/templates/operator.yaml
+++ b/charts/baremetal-operator/templates/operator.yaml
@@ -39,7 +39,7 @@ spec:
             - name: DEPLOY_RAMDISK_URL
               value: "{{ .Values.operator.deploy_ramdisk_url }}"
             - name: IRONIC_ENDPOINT
-              value: {{ .Values.operator.ironic_api_url }}
+              value: "{{ .Values.operator.ironic_api_url }}"
             - name: IRONIC_INSPECTOR_ENDPOINT
               value: "{{ .Values.operator.ironic_inspector_url }}"
         # Temporary workaround to talk to an external Ironic process until Ironic is running in this pod.

--- a/charts/baremetal-operator/templates/operator.yaml
+++ b/charts/baremetal-operator/templates/operator.yaml
@@ -16,7 +16,8 @@ spec:
       serviceAccountName: metal3-baremetal-operator
       containers:
         - name: baremetal-operator
-          image: {{ .Values.operator.image }}
+          image: {{ .Values.operator.image.fullName }}
+          imagePullPolicy: {{ .Values.operator.image.pullPolicy }}
           ports:
           - containerPort: 60000
             name: metrics

--- a/charts/baremetal-operator/templates/operator.yaml
+++ b/charts/baremetal-operator/templates/operator.yaml
@@ -46,9 +46,9 @@ spec:
         # Temporary workaround to talk to an external Ironic process until Ironic is running in this pod.
         - name: ironic-proxy
           image: alpine/socat
-          command: ["socat", "tcp-listen:6385,fork,reuseaddr", "tcp-connect:172.22.0.1:6385"]
+          command: ["socat", "tcp-listen:6385,fork,reuseaddr", "tcp-connect:{{- .Values.ironic.configuration.provisioning_ip }}:6385"]
           imagePullPolicy: Always
         - name: ironic-inspector-proxy
           image: alpine/socat
-          command: ["socat", "tcp-listen:5050,fork,reuseaddr", "tcp-connect:172.22.0.1:5050"]
+          command: ["socat", "tcp-listen:5050,fork,reuseaddr", "tcp-connect:{{- .Values.ironic.configuration.provisioning_ip }}"]
           imagePullPolicy: Always

--- a/charts/baremetal-operator/templates/operator.yaml
+++ b/charts/baremetal-operator/templates/operator.yaml
@@ -37,7 +37,7 @@ spec:
             - name: DEPLOY_KERNEL_URL
               value: "http://{{- .Values.ironic.configuration.provisioning_ip }}/{{- .Values.operator.deploy_kernel_path }}"
             - name: DEPLOY_RAMDISK_URL
-              value: "{{ .Values.operator.deploy_ramdisk_url }}"
+              value: "http://{{- .Values.ironic.configuration.provisioning_ip }}/{{- .Values.operator.deploy_ramdisk_path }}"
             - name: IRONIC_ENDPOINT
               value: "{{ .Values.operator.ironic_api_url }}"
             - name: IRONIC_INSPECTOR_ENDPOINT

--- a/charts/baremetal-operator/templates/operator.yaml
+++ b/charts/baremetal-operator/templates/operator.yaml
@@ -39,9 +39,9 @@ spec:
             - name: DEPLOY_RAMDISK_URL
               value: "http://{{- .Values.ironic.configuration.provisioning_ip }}/{{- .Values.operator.deploy_ramdisk_path }}"
             - name: IRONIC_ENDPOINT
-              value: "{{ .Values.operator.ironic_api_url }}"
+              value: "http://{{- .Values.ironic.configuration.provisioning_ip }}:6385/v1/"
             - name: IRONIC_INSPECTOR_ENDPOINT
-              value: "{{ .Values.operator.ironic_inspector_url }}"
+              value: "http://{{- .Values.ironic.configuration.provisioning_ip }}:5050/v1/"
         # Temporary workaround to talk to an external Ironic process until Ironic is running in this pod.
         - name: ironic-proxy
           image: alpine/socat

--- a/charts/baremetal-operator/values.yaml
+++ b/charts/baremetal-operator/values.yaml
@@ -27,6 +27,7 @@ ironic:
     ironic: false
     inspector: false
     dnsmasq: false
+    dualboot_ipxe: false
   ironic_storage:
     volume_capacity: 10Gi
     hostPath: "/opt/metal3-dev-env/ironic/"

--- a/charts/baremetal-operator/values.yaml
+++ b/charts/baremetal-operator/values.yaml
@@ -29,6 +29,7 @@ ironic:
     dnsmasq: false
     dualboot_ipxe: false
     httpd: false
+    inspector_ipxe: false
   ironic_storage:
     volume_capacity: 10Gi
     hostPath: "/opt/metal3-dev-env/ironic/"

--- a/charts/baremetal-operator/values.yaml
+++ b/charts/baremetal-operator/values.yaml
@@ -24,6 +24,7 @@ ironic:
     fast_track: true
   config_override:
     ironic: false
+    inspector: false
   ironic_storage:
     volume_capacity: 10Gi
     hostPath: "/opt/metal3-dev-env/ironic/"

--- a/charts/baremetal-operator/values.yaml
+++ b/charts/baremetal-operator/values.yaml
@@ -18,7 +18,7 @@ ironic:
     automated_clean: true
     api_workers: '4'
     http_port: "80"
-    fast_track: true
+    fast_track: false
     ipv: "4"
   config_override:
     ironic: false
@@ -62,3 +62,11 @@ persistence:
     enabled: true
     path: "/opt/metal3-dev-env/ironic/"
   storageClassName: "default"
+init_bootstrap:
+  enabled: true
+  image:
+    fullName: "quay.io/metal3-io/ironic:latest"
+    pullPolicy: IfNotPresent
+  provisioning_files:
+    xenial-server-cloudimg-amd64-disk1.img: https://cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-amd64-disk1.img
+    ironic-python-agent.tar: https://images.rdoproject.org/train/rdo_trunk/current-tripleo/ironic-python-agent.tar

--- a/charts/baremetal-operator/values.yaml
+++ b/charts/baremetal-operator/values.yaml
@@ -30,6 +30,7 @@ ironic:
     dualboot_ipxe: false
     httpd: false
     inspector_ipxe: false
+    mariadb: false
   ironic_storage:
     volume_capacity: 10Gi
     hostPath: "/opt/metal3-dev-env/ironic/"

--- a/charts/baremetal-operator/values.yaml
+++ b/charts/baremetal-operator/values.yaml
@@ -28,6 +28,7 @@ ironic:
     inspector: false
     dnsmasq: false
     dualboot_ipxe: false
+    httpd: false
   ironic_storage:
     volume_capacity: 10Gi
     hostPath: "/opt/metal3-dev-env/ironic/"

--- a/charts/baremetal-operator/values.yaml
+++ b/charts/baremetal-operator/values.yaml
@@ -17,14 +17,16 @@ ironic:
     provisioning_ip: "172.22.0.1"
     automated_clean: true
     api_workers: '4'
-    dnsmasq_except_interface: "lo"
+    dnsmasq_except_interface: lo
     http_port: "80"
     dhcp_range: "172.22.0.10,172.22.0.100"
     mariadb_password: "e8ca990d79d351eacda0"
     fast_track: true
+    ipv: "4"
   config_override:
     ironic: false
     inspector: false
+    dnsmasq: false
   ironic_storage:
     volume_capacity: 10Gi
     hostPath: "/opt/metal3-dev-env/ironic/"

--- a/charts/baremetal-operator/values.yaml
+++ b/charts/baremetal-operator/values.yaml
@@ -1,8 +1,6 @@
 namespace: "metal3"
 
 operator:
-  ironic_api_url: "http://172.22.0.1:6385/v1/"
-  ironic_inspector_url: "http://172.22.0.1:5050/v1/"
   deploy_kernel_path: "/images/ironic-python-agent.kernel"
   deploy_ramdisk_path: "/images/ironic-python-agent.initramfs"
   image: "quay.io/metal3-io/baremetal-operator:latest"

--- a/charts/baremetal-operator/values.yaml
+++ b/charts/baremetal-operator/values.yaml
@@ -50,3 +50,8 @@ dnsmasq:
     pullPolicy: IfNotPresent
   dhcp_range: "172.22.0.10,172.22.0.100"
   except_interface: lo
+
+httpd:
+  image:
+    fullName: "quay.io/metal3-io/ironic:latest"
+    pullPolicy: IfNotPresent

--- a/charts/baremetal-operator/values.yaml
+++ b/charts/baremetal-operator/values.yaml
@@ -17,9 +17,7 @@ ironic:
     provisioning_ip: "172.22.0.1"
     automated_clean: true
     api_workers: '4'
-    dnsmasq_except_interface: lo
     http_port: "80"
-    dhcp_range: "172.22.0.10,172.22.0.100"
     fast_track: true
     ipv: "4"
   config_override:
@@ -45,3 +43,10 @@ mariadb:
     fullName: "quay.io/metal3-io/ironic:latest"
     pullPolicy: IfNotPresent
   password: "e8ca990d79d351eacda0"
+
+dnsmasq:
+  image:
+    fullName: "quay.io/metal3-io/ironic:latest"
+    pullPolicy: IfNotPresent
+  dhcp_range: "172.22.0.10,172.22.0.100"
+  except_interface: lo

--- a/charts/baremetal-operator/values.yaml
+++ b/charts/baremetal-operator/values.yaml
@@ -15,10 +15,15 @@ ironic:
   configuration:
     provisioning_interface: "provisioning"
     provisioning_ip: "172.22.0.1"
+    automated_clean: true
+    api_workers: '4'
     dnsmasq_except_interface: "lo"
     http_port: "80"
     dhcp_range: "172.22.0.10,172.22.0.100"
     mariadb_password: "e8ca990d79d351eacda0"
+    fast_track: true
+  config_override:
+    ironic: false
   ironic_storage:
     volume_capacity: 10Gi
     hostPath: "/opt/metal3-dev-env/ironic/"

--- a/charts/baremetal-operator/values.yaml
+++ b/charts/baremetal-operator/values.yaml
@@ -9,9 +9,9 @@ operator:
 
 ironic:
   replicaCount: 1
-  images:
-    ironic_aio: "quay.io/metal3-io/ironic:latest"
-    ironic_inspector: "quay.io/metal3-io/ironic-inspector:latest"
+  image:
+    fullName: "quay.io/metal3-io/ironic:latest"
+    pullPolicy: IfNotPresent
   configuration:
     provisioning_interface: "provisioning"
     provisioning_ip: "172.22.0.1"
@@ -35,3 +35,8 @@ ironic:
     volume_capacity: 10Gi
     hostPath: "/opt/metal3-dev-env/ironic/"
   nodeSelector: {}
+
+ironic_inspector:
+  image:
+    fullName: "quay.io/metal3-io/ironic-inspector:latest"
+    pullPolicy: IfNotPresent

--- a/charts/baremetal-operator/values.yaml
+++ b/charts/baremetal-operator/values.yaml
@@ -55,3 +55,10 @@ httpd:
   image:
     fullName: "quay.io/metal3-io/ironic:latest"
     pullPolicy: IfNotPresent
+
+persistence:
+  volume_capacity: 10Gi
+  hostPath:
+    enabled: true
+    path: "/opt/metal3-dev-env/ironic/"
+  storageClassName: "default"

--- a/charts/baremetal-operator/values.yaml
+++ b/charts/baremetal-operator/values.yaml
@@ -4,7 +4,7 @@ operator:
   ironic_api_url: "http://172.22.0.1:6385/v1/"
   ironic_inspector_url: "http://172.22.0.1:5050/v1/"
   deploy_kernel_path: "/images/ironic-python-agent.kernel"
-  deploy_ramdisk_url: "http://172.22.0.1/images/ironic-python-agent.initramfs"
+  deploy_ramdisk_path: "/images/ironic-python-agent.initramfs"
   image: "quay.io/metal3-io/baremetal-operator:latest"
 
 ironic:

--- a/charts/baremetal-operator/values.yaml
+++ b/charts/baremetal-operator/values.yaml
@@ -12,7 +12,7 @@ ironic:
   images:
     ironic_aio: "quay.io/metal3-io/ironic:latest"
     ironic_inspector: "quay.io/metal3-io/ironic-inspector:latest"
-  ironic_conf:
+  configuration:
     provisioning_interface: "provisioning"
     dnsmasq_except_interface: "lo"
     http_port: "80"

--- a/charts/baremetal-operator/values.yaml
+++ b/charts/baremetal-operator/values.yaml
@@ -3,7 +3,9 @@ namespace: "metal3"
 operator:
   deploy_kernel_path: "/images/ironic-python-agent.kernel"
   deploy_ramdisk_path: "/images/ironic-python-agent.initramfs"
-  image: "quay.io/metal3-io/baremetal-operator:latest"
+  image:
+    fullName: "quay.io/metal3-io/baremetal-operator:latest"
+    pullPolicy: IfNotPresent
 
 ironic:
   replicaCount: 1

--- a/charts/baremetal-operator/values.yaml
+++ b/charts/baremetal-operator/values.yaml
@@ -3,7 +3,7 @@ namespace: "metal3"
 operator:
   ironic_api_url: "http://172.22.0.1:6385/v1/"
   ironic_inspector_url: "http://172.22.0.1:5050/v1/"
-  deploy_kernel_url: "http://172.22.0.1/images/ironic-python-agent.kernel"
+  deploy_kernel_path: "/images/ironic-python-agent.kernel"
   deploy_ramdisk_url: "http://172.22.0.1/images/ironic-python-agent.initramfs"
   image: "quay.io/metal3-io/baremetal-operator:latest"
 
@@ -14,6 +14,7 @@ ironic:
     ironic_inspector: "quay.io/metal3-io/ironic-inspector:latest"
   configuration:
     provisioning_interface: "provisioning"
+    provisioning_ip: "172.22.0.1"
     dnsmasq_except_interface: "lo"
     http_port: "80"
     dhcp_range: "172.22.0.10,172.22.0.100"

--- a/charts/baremetal-operator/values.yaml
+++ b/charts/baremetal-operator/values.yaml
@@ -20,7 +20,6 @@ ironic:
     dnsmasq_except_interface: lo
     http_port: "80"
     dhcp_range: "172.22.0.10,172.22.0.100"
-    mariadb_password: "e8ca990d79d351eacda0"
     fast_track: true
     ipv: "4"
   config_override:
@@ -40,3 +39,9 @@ ironic_inspector:
   image:
     fullName: "quay.io/metal3-io/ironic-inspector:latest"
     pullPolicy: IfNotPresent
+
+mariadb:
+  image:
+    fullName: "quay.io/metal3-io/ironic:latest"
+    pullPolicy: IfNotPresent
+  password: "e8ca990d79d351eacda0"


### PR DESCRIPTION
Introduce external config files and entry points for containers in baremetal-operator.  It can be applied to containers witch require custom configuration parameters.